### PR TITLE
Feat/php8.1

### DIFF
--- a/.github/workflows/php-checks.yml
+++ b/.github/workflows/php-checks.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.4', '8.0', '8.1']
     name: PHP ${{ matrix.php-versions }} tests
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 
 - Updated `symfony/filesystem` to version `5`.
 
+### Breaking changes
+
+- The `Naneau\FileGen\Directory::scan(string $path)` method now returns `null`
+  instead of `false`, if no child node is found.
+
 ## 0.2.0
 
 ### PHP support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,26 @@
 # Changelog
 
+## 0.3.0
+
+### PHP support
+
+- Dropped support for PHP `7.3`.
+- Added support for PHP `8.1`.
+
+### 3rd party updates
+
+- Updated `symfony/filesystem` to version `5`.
+
 ## 0.2.0
 
 ### PHP support
 
 - Dropped support for PHP `7.2`.
 - Added support for PHP `8.0`.
+
+### 3rd party updates
+
+- Updated `symfony/filesystem` to version `4`.
 
 ## 0.1.0
 

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,8 @@
   },
   "minimum-stability": "stable",
   "require": {
-    "php": "7.3.* || 7.4.* || 8.0.*",
-    "symfony/filesystem": "~4.4"
+    "php": "7.4.* || 8.0.* || 8.1.*",
+    "symfony/filesystem": "~5.4"
   },
   "require-dev": {
     "phpstan/phpstan": "0.12.85",

--- a/composer.json
+++ b/composer.json
@@ -44,11 +44,11 @@
     "symfony/filesystem": "~5.4"
   },
   "require-dev": {
-    "phpstan/phpstan": "0.12.85",
-    "phpunit/phpunit": "~8.5",
-    "squizlabs/php_codesniffer": "^3.5",
-    "symfony/console": "~4.4",
-    "twig/twig": "~2.1"
+    "phpstan/phpstan": "1.2.0",
+    "phpunit/phpunit": "~9.5",
+    "squizlabs/php_codesniffer": "~3.6",
+    "symfony/console": "~5.4",
+    "twig/twig": "~3.3"
   },
   "suggest": {
     "twig/twig": "Allows for templated files",

--- a/src/Naneau/FileGen/AccessRights.php
+++ b/src/Naneau/FileGen/AccessRights.php
@@ -29,7 +29,7 @@ abstract class AccessRights extends Node
     /**
      * Set the mode (as an int)
      */
-    public function setMode(int $mode): self
+    public function setMode(?int $mode): self
     {
         $this->mode = $mode;
 

--- a/src/Naneau/FileGen/AccessRights.php
+++ b/src/Naneau/FileGen/AccessRights.php
@@ -8,10 +8,8 @@ abstract class AccessRights extends Node
 {
     /**
      * The mode
-     *
-     * @var int
      */
-    private $mode;
+    private int $mode;
 
     public function __construct(string $name, int $mode)
     {

--- a/src/Naneau/FileGen/AccessRights.php
+++ b/src/Naneau/FileGen/AccessRights.php
@@ -9,9 +9,9 @@ abstract class AccessRights extends Node
     /**
      * The mode
      */
-    private int $mode;
+    private ?int $mode;
 
-    public function __construct(string $name, int $mode)
+    public function __construct(string $name, ?int $mode = null)
     {
         parent::__construct($name);
 
@@ -21,7 +21,7 @@ abstract class AccessRights extends Node
     /**
      * Get the mode (as an int)
      */
-    public function getMode(): int
+    public function getMode(): ?int
     {
         return $this->mode;
     }

--- a/src/Naneau/FileGen/Console/Helper/ParameterHelper.php
+++ b/src/Naneau/FileGen/Console/Helper/ParameterHelper.php
@@ -19,10 +19,8 @@ class ParameterHelper implements HelperInterface
 {
     /**
      * The helperset
-     *
-     * @var HelperSet|null
      */
-    private $helperSet;
+    private ?HelperSet $helperSet;
 
     /**
      * Ask for a parameter's value
@@ -58,8 +56,6 @@ class ParameterHelper implements HelperInterface
 
     /**
      * Sets the helper set associated with this helper.
-     *
-     * @param HelperSet $helperSet A HelperSet instance
      */
     public function setHelperSet(HelperSet $helperSet = null): void
     {

--- a/src/Naneau/FileGen/Console/Helper/ParameterHelper.php
+++ b/src/Naneau/FileGen/Console/Helper/ParameterHelper.php
@@ -51,7 +51,10 @@ class ParameterHelper implements HelperInterface
             $question = new Question($parameter->getDescription());
         }
 
-        return $this->getQuestionHelper()->ask($input, $output, $question);
+        $answer = $this->getQuestionHelper()->ask($input, $output, $question);
+        assert(is_string($answer));
+
+        return $answer;
     }
 
     /**

--- a/src/Naneau/FileGen/Directory.php
+++ b/src/Naneau/FileGen/Directory.php
@@ -36,11 +36,9 @@ class Directory extends AccessRights implements Iterator
      * exists, it has a child directory node `bar`, which should have a child
      * node `baz`
      *
-     * Will return either the found child node, or boolean false
-     *
-     * @return Node|bool
+     * Will return either the found child node, or null.
      */
-    public function scan(string $path)
+    public function scan(string $path): ?Node
     {
         // Start scanning at the root (this dir)
         $node = $this;
@@ -50,12 +48,12 @@ class Directory extends AccessRights implements Iterator
 
             // Can't find children if $node is not a directory
             if (!($node instanceof Directory)) {
-                return false;
+                return null;
             }
 
             // If the current node doesn't have the item, $path doesn't exist (fully)
             if (!$node->hasChild($item)) {
-                return false;
+                return null;
             }
 
             // New parent node

--- a/src/Naneau/FileGen/Directory.php
+++ b/src/Naneau/FileGen/Directory.php
@@ -111,11 +111,11 @@ class Directory extends AccessRights implements Iterator
         return false;
     }
 
-	/**
-	 * Get a child with name $name
-	 *
-	 * @throws Exception If the node was not found.
-	 */
+    /**
+     * Get a child with name $name
+     *
+     * @throws Exception If the node was not found.
+     */
     public function getChild(string $name): Node
     {
         foreach ($this as $node) {

--- a/src/Naneau/FileGen/Directory.php
+++ b/src/Naneau/FileGen/Directory.php
@@ -3,7 +3,7 @@ namespace Naneau\FileGen;
 
 use Naneau\FileGen\Exception as FileGenException;
 
-use \Iterator;
+use Iterator;
 
 /**
  * A directory, that can contain children (other directories, files, symlinks)
@@ -14,17 +14,15 @@ class Directory extends AccessRights implements Iterator
 {
     /**
      * Position of the iteration
-     *
-     * @var int
      */
-    private $position = 0;
+    private int $position = 0;
 
     /**
      * Child nodes
      *
      * @var Node[]
      */
-    private $children = [];
+    private array $children = [];
 
     public function __construct(string $name, int $mode = 0777)
     {
@@ -72,7 +70,7 @@ class Directory extends AccessRights implements Iterator
      *
      * @return Node[]
      */
-    public function getChildren()
+    public function getChildren(): array
     {
         return $this->children;
     }
@@ -115,9 +113,11 @@ class Directory extends AccessRights implements Iterator
         return false;
     }
 
-    /**
-     * Get a child with name $name
-     */
+	/**
+	 * Get a child with name $name
+	 *
+	 * @throws Exception If the node was not found.
+	 */
     public function getChild(string $name): Node
     {
         foreach ($this as $node) {

--- a/src/Naneau/FileGen/Exception.php
+++ b/src/Naneau/FileGen/Exception.php
@@ -1,7 +1,7 @@
 <?php
 namespace Naneau\FileGen;
 
-use \Exception as NativeException;
+use Exception as NativeException;
 
 /**
  * FileGen exception

--- a/src/Naneau/FileGen/File.php
+++ b/src/Naneau/FileGen/File.php
@@ -59,8 +59,8 @@ class File extends AccessRights
      * Set the content generator
      *
      * @param  ContentGenerator|string $contentGenerator
-	 *
-	 * @throws InvalidArgumentException If the content generator is of the wrong type.
+     *
+     * @throws InvalidArgumentException If the content generator is of the wrong type.
      */
     public function setContentGenerator($contentGenerator): self
     {

--- a/src/Naneau/FileGen/File.php
+++ b/src/Naneau/FileGen/File.php
@@ -4,7 +4,7 @@ namespace Naneau\FileGen;
 use Naneau\FileGen\File\Contents as ContentGenerator;
 use Naneau\FileGen\File\Contents\StringBased as StringContents;
 
-use \InvalidArgumentException;
+use InvalidArgumentException;
 
 /**
  * A file
@@ -13,10 +13,8 @@ class File extends AccessRights
 {
     /**
      * Contents of the file
-     *
-     * @var ContentGenerator
      */
-    private $contentGenerator;
+    private ContentGenerator $contentGenerator;
 
     /**
      * Constructor
@@ -61,6 +59,8 @@ class File extends AccessRights
      * Set the content generator
      *
      * @param  ContentGenerator|string $contentGenerator
+	 *
+	 * @throws InvalidArgumentException If the content generator is of the wrong type.
      */
     public function setContentGenerator($contentGenerator): self
     {

--- a/src/Naneau/FileGen/File/Contents.php
+++ b/src/Naneau/FileGen/File/Contents.php
@@ -8,8 +8,6 @@ interface Contents
 {
     /**
      * Get the contents for a file
-     *
-     * @return string
-     **/
-    public function getContents();
+     */
+    public function getContents(): string;
 }

--- a/src/Naneau/FileGen/File/Contents/Copy.php
+++ b/src/Naneau/FileGen/File/Contents/Copy.php
@@ -14,16 +14,11 @@ class Copy implements Contents
      */
     private string $from;
 
-    public function __construct(string $from)
-    {
-        $this->setFrom($from);
-    }
-
-	/**
-	 * Get the contents
-	 *
-	 * @throws Exception If the contents can't be read.
-	 */
+    /**
+     * Get the contents
+     *
+     * @throws Exception If the contents can't be read.
+     */
     public function getContents(): string
     {
         // Make sure file exists
@@ -44,6 +39,11 @@ class Copy implements Contents
         }
 
         return $contents;
+    }
+
+    public function __construct(string $from)
+    {
+        $this->setFrom($from);
     }
 
     /**

--- a/src/Naneau/FileGen/File/Contents/Copy.php
+++ b/src/Naneau/FileGen/File/Contents/Copy.php
@@ -11,19 +11,19 @@ class Copy implements Contents
 {
     /**
      * The source file
-     *
-     * @var string
      */
-    private $from;
+    private string $from;
 
     public function __construct(string $from)
     {
         $this->setFrom($from);
     }
 
-    /**
-     * Get the contents
-     */
+	/**
+	 * Get the contents
+	 *
+	 * @throws Exception If the contents can't be read.
+	 */
     public function getContents(): string
     {
         // Make sure file exists

--- a/src/Naneau/FileGen/File/Contents/StringBased.php
+++ b/src/Naneau/FileGen/File/Contents/StringBased.php
@@ -10,10 +10,8 @@ class StringBased implements Contents
 {
     /**
      * Contents of the file
-     *
-     * @var string
      */
-    private $contents;
+    private string $contents;
 
     public function __construct(string $contents)
     {

--- a/src/Naneau/FileGen/File/Contents/Twig.php
+++ b/src/Naneau/FileGen/File/Contents/Twig.php
@@ -13,17 +13,15 @@ class Twig implements FileContents, Parameterized
 {
     /**
      * The twig template
-     *
-     * @var TwigTemplate
      */
-    private $template;
+    private TwigTemplate $template;
 
     /**
      * The parameters
      *
      * @var string[]
      */
-    private $parameters;
+    private array $parameters;
 
     /**
      * Constructor

--- a/src/Naneau/FileGen/Generator.php
+++ b/src/Naneau/FileGen/Generator.php
@@ -16,24 +16,20 @@ class Generator implements Parameterized
 {
     /**
      * Root of the generation
-     *
-     * @var string
      */
-    private $root;
+    private string $root;
 
     /**
      * The parameters
      *
      * @var string[]
      */
-    private $parameters;
+    private array $parameters;
 
     /**
      * The symfony filesystem
-     *
-     * @var Filesystem
      */
-    private $fileSystem;
+    private Filesystem $fileSystem;
 
     /**
      * Constructor
@@ -119,11 +115,12 @@ class Generator implements Parameterized
         return $this;
     }
 
-    /**
-     * Create a node
-     *
-     * @param Node $node
-     */
+	/**
+	 * Create a node
+	 *
+	 * @throws NodeExistsException 		If the node already exists.
+	 * @throws InvalidArgumentException If the node type is invalid.
+	 */
     private function createNode(Node $node): void
     {
         // See if it exists
@@ -149,9 +146,11 @@ class Generator implements Parameterized
         }
     }
 
-    /**
-     * Create a file
-     */
+	/**
+	 * Create a file
+	 *
+	 * @throws GeneratorException If the file could not be created.
+	 */
     private function createFile(File $file): self
     {
         // Full path to the file
@@ -179,9 +178,11 @@ class Generator implements Parameterized
         return $this;
     }
 
-    /**
-     * Create a directory
-     */
+	/**
+	 * Create a directory
+	 *
+	 * @throws GeneratorException If the directory could not be created.
+	 */
     private function createDirectory(Directory $directory): self
     {
         $fullPath = $this->getNodePath($directory);
@@ -212,9 +213,11 @@ class Generator implements Parameterized
         return $this;
     }
 
-    /**
-     * Create a symlink
-     */
+	/**
+	 * Create a symlink
+	 *
+	 * @throws GeneratorException If the symlink could not be created.
+	 */
     private function createLink(SymLink $link): self
     {
         $fullToPath = $this->getNodePath($link);

--- a/src/Naneau/FileGen/Generator.php
+++ b/src/Naneau/FileGen/Generator.php
@@ -115,12 +115,12 @@ class Generator implements Parameterized
         return $this;
     }
 
-	/**
-	 * Create a node
-	 *
-	 * @throws NodeExistsException 		If the node already exists.
-	 * @throws InvalidArgumentException If the node type is invalid.
-	 */
+    /**
+     * Create a node
+     *
+     * @throws NodeExistsException      If the node already exists.
+     * @throws InvalidArgumentException If the node type is invalid.
+     */
     private function createNode(Node $node): void
     {
         // See if it exists
@@ -146,11 +146,11 @@ class Generator implements Parameterized
         }
     }
 
-	/**
-	 * Create a file
-	 *
-	 * @throws GeneratorException If the file could not be created.
-	 */
+    /**
+     * Create a file
+     *
+     * @throws GeneratorException If the file could not be created.
+     */
     private function createFile(File $file): self
     {
         // Full path to the file
@@ -178,11 +178,11 @@ class Generator implements Parameterized
         return $this;
     }
 
-	/**
-	 * Create a directory
-	 *
-	 * @throws GeneratorException If the directory could not be created.
-	 */
+    /**
+     * Create a directory
+     *
+     * @throws GeneratorException If the directory could not be created.
+     */
     private function createDirectory(Directory $directory): self
     {
         $fullPath = $this->getNodePath($directory);
@@ -213,11 +213,11 @@ class Generator implements Parameterized
         return $this;
     }
 
-	/**
-	 * Create a symlink
-	 *
-	 * @throws GeneratorException If the symlink could not be created.
-	 */
+    /**
+     * Create a symlink
+     *
+     * @throws GeneratorException If the symlink could not be created.
+     */
     private function createLink(SymLink $link): self
     {
         $fullToPath = $this->getNodePath($link);

--- a/src/Naneau/FileGen/Generator.php
+++ b/src/Naneau/FileGen/Generator.php
@@ -162,7 +162,9 @@ class Generator implements Parameterized
         try {
             $this->getFilesystem()->dumpFile($fullPath, $contents);
             if ($file->hasMode()) {
-                $this->getFilesystem()->chmod($fullPath, $file->getMode());
+                $mode = $file->getMode();
+                assert(is_int($mode));
+                $this->getFilesystem()->chmod($fullPath, $mode);
             }
         } catch (FilesystemIOException $filesystemException) {
             throw new GeneratorException(
@@ -190,7 +192,9 @@ class Generator implements Parameterized
         // Try to make it
         try {
             if ($directory->hasMode()) {
-                $this->getFilesystem()->mkdir($fullPath, $directory->getMode());
+                $mode = $directory->getMode();
+                assert(is_int($mode));
+                $this->getFilesystem()->mkdir($fullPath, $mode);
             } else {
                 $this->getFilesystem()->mkdir($fullPath);
             }

--- a/src/Naneau/FileGen/Node.php
+++ b/src/Naneau/FileGen/Node.php
@@ -8,17 +8,13 @@ class Node
 {
     /**
      * Name of the node
-     *
-     * @var string
      */
-    private $name;
+    private string $name;
 
     /**
      * Parent node
-     *
-     * @var Node
      */
-    private $parent;
+    private Node $parent;
 
     public function __construct(string $name)
     {

--- a/src/Naneau/FileGen/Parameter/Parameter.php
+++ b/src/Naneau/FileGen/Parameter/Parameter.php
@@ -19,7 +19,7 @@ class Parameter
     /**
      * The default value
      *
-     * @var mixed
+     * @var bool|float|int|string|null
      */
     private $defaultValue;
 
@@ -81,7 +81,7 @@ class Parameter
     /**
      * Get the default value
      *
-     * @return mixed
+     * @return bool|float|int|string|null
      */
     public function getDefaultValue()
     {
@@ -91,7 +91,7 @@ class Parameter
     /**
      * Set the default value
      *
-     * @param mixed $defaultValue
+     * @param bool|float|int|string|null $defaultValue
      */
     public function setDefaultValue($defaultValue): self
     {

--- a/src/Naneau/FileGen/Parameter/Parameter.php
+++ b/src/Naneau/FileGen/Parameter/Parameter.php
@@ -8,17 +8,13 @@ class Parameter
 {
     /**
      * Name of the parameter
-     *
-     * @var string
      */
-    private $name;
+    private string $name;
 
     /**
      * Human readable description
-     *
-     * @var string
      */
-    private $description;
+    private string $description;
 
     /**
      * The default value
@@ -32,10 +28,8 @@ class Parameter
      *
      * This is checked outside of the $defaultValue property, as `null` is a
      * valid default value
-     *
-     * @var bool
      */
-    private $hasDefaultValue = false;
+    private bool $hasDefaultValue = false;
 
     /**
      * Constructor

--- a/src/Naneau/FileGen/Parameter/Set.php
+++ b/src/Naneau/FileGen/Parameter/Set.php
@@ -3,7 +3,7 @@ namespace Naneau\FileGen\Parameter;
 
 use Naneau\FileGen\Exception as FileGenException;
 
-use \Iterator;
+use Iterator;
 
 /**
  * A set of parameters
@@ -14,17 +14,15 @@ class Set implements Iterator
 {
     /**
      * Position of the iteration
-     *
-     * @var int
      */
-    private $position = 0;
+    private int $position = 0;
 
     /**
      * Parameters
      *
      * @var Parameter[]
      */
-    private $parameters = [];
+    private array $parameters = [];
 
     /**
      * Add a new parameter
@@ -52,6 +50,8 @@ class Set implements Iterator
 
     /**
      * Get a parameter by name
+     *
+     * @throws FileGenException If the parameter can't be found.
      */
     public function get(string $name): Parameter
     {
@@ -85,8 +85,6 @@ class Set implements Iterator
 
     /**
      * Get current key
-     *
-     * @return int
      */
     public function key(): int
     {

--- a/src/Naneau/FileGen/Parameterized.php
+++ b/src/Naneau/FileGen/Parameterized.php
@@ -11,7 +11,7 @@ interface Parameterized
      *
      * @return string[]
      */
-    public function getParameters();
+    public function getParameters(): array;
 
     /**
      * Set the parameters

--- a/src/Naneau/FileGen/Structure.php
+++ b/src/Naneau/FileGen/Structure.php
@@ -14,10 +14,8 @@ class Structure extends Directory
 {
     /**
      * The parameter definition
-     *
-     * @var ParameterSet
      */
-    private $parameterDefinition;
+    private ParameterSet $parameterDefinition;
 
     /**
      * Constructor

--- a/src/Naneau/FileGen/SymLink.php
+++ b/src/Naneau/FileGen/SymLink.php
@@ -8,10 +8,8 @@ class SymLink extends Node
 {
     /**
      * The endpoint of the link
-     *
-     * @var string
      */
-    private $endpoint;
+    private string $endpoint;
 
     public function __construct(string $from, string $to)
     {

--- a/tests/Naneau/FileGen/Test/Parameter/SetTest.php
+++ b/tests/Naneau/FileGen/Test/Parameter/SetTest.php
@@ -15,8 +15,12 @@ class SetTest extends \PHPUnit\Framework\TestCase
             ->add('foo', 'bar')
             ->add('baz', 'qux');
 
-        $set->get('foo');
-        $set->get('baz');
+
+        $foo = $set->get('foo');
+        $this->assertEquals('bar', $foo->getDescription());
+
+        $baz = $set->get('baz');
+        $this->assertEquals('qux', $baz->getDescription());
     }
 
     /**

--- a/tests/Naneau/FileGen/Test/Structure/StructureTest.php
+++ b/tests/Naneau/FileGen/Test/Structure/StructureTest.php
@@ -43,6 +43,11 @@ class StructureTest extends \PHPUnit\Framework\TestCase
             SymLink::class,
             $structure->scan('to/that')
         );
+
+        self::assertEquals(
+            null,
+            $structure->scan('path/to/nowhere')
+        );
     }
 
     /**


### PR DESCRIPTION
# Changelog

## PHP support

- Dropped support for PHP `7.3`.
- Added support for PHP `8.1`.

## 3rd party updates

- Updated `symfony/filesystem` to version `5`.

## Breaking changes

- The `Naneau\FileGen\Directory::scan(string $path)` method now returns `null`
  instead of `false`, if no child node is found.